### PR TITLE
Add auto-badge component

### DIFF
--- a/apps/v4/registry/new-york-v4/examples/auto-badge-demo.tsx
+++ b/apps/v4/registry/new-york-v4/examples/auto-badge-demo.tsx
@@ -1,0 +1,14 @@
+import { AutoBadge } from "@/registry/new-york-v4/ui/auto-badge"
+
+export default function AutoBadgeDemo() {
+  return (
+    <div className="flex items-center space-x-4">
+      <AutoBadge>Default</AutoBadge>
+      <AutoBadge variant="secondary">Secondary</AutoBadge>
+      <AutoBadge variant="outline">Outline</AutoBadge>
+      <AutoBadge variant="ghost">Ghost</AutoBadge>
+      <AutoBadge size="sm">Small</AutoBadge>
+      <AutoBadge size="lg">Large</AutoBadge>
+    </div>
+  )
+}

--- a/apps/v4/registry/new-york-v4/ui/auto-badge.tsx
+++ b/apps/v4/registry/new-york-v4/ui/auto-badge.tsx
@@ -1,0 +1,52 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+import { cn } from "@/lib/utils"
+
+const auto-badgeVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline"
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10"
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface AutoBadgeProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof auto-badgeVariants> {
+  asChild?: boolean
+}
+
+const AutoBadge = React.forwardRef<HTMLButtonElement, AutoBadgeProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(auto-badgeVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+AutoBadge.displayName = "AutoBadge"
+
+export { AutoBadge, auto-badgeVariants }


### PR DESCRIPTION
Add auto-badge component with auto-merge functionality

This PR adds the auto-badge component to the React registry.

Files added/updated:
- apps/v4/registry/new-york-v4/ui/auto-badge.tsx
- apps/v4/registry/new-york-v4/examples/auto-badge-demo.tsx