### PR TITLE
Add zinc-button component

### DIFF
--- a/apps/v4/registry/new-york-v4/examples/zinc-button-demo.tsx
+++ b/apps/v4/registry/new-york-v4/examples/zinc-button-demo.tsx
@@ -1,0 +1,14 @@
+import { ZincButton } from "@/registry/new-york-v4/ui/zinc-button"
+
+export default function ZincButtonDemo() {
+  return (
+    <div className="flex items-center space-x-4">
+      <ZincButton>Default</ZincButton>
+      <ZincButton variant="secondary">Secondary</ZincButton>
+      <ZincButton variant="outline">Outline</ZincButton>
+      <ZincButton variant="ghost">Ghost</ZincButton>
+      <ZincButton size="sm">Small</ZincButton>
+      <ZincButton size="lg">Large</ZincButton>
+    </div>
+  )
+}

--- a/apps/v4/registry/new-york-v4/ui/zinc-button.tsx
+++ b/apps/v4/registry/new-york-v4/ui/zinc-button.tsx
@@ -1,0 +1,52 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+import { cn } from "@/lib/utils"
+
+const zinc-buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline"
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10"
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ZincButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof zinc-buttonVariants> {
+  asChild?: boolean
+}
+
+const ZincButton = React.forwardRef<HTMLButtonElement, ZincButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(zinc-buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+ZincButton.displayName = "ZincButton"
+
+export { ZincButton, zinc-buttonVariants }


### PR DESCRIPTION
Add zinc-button component with modern zinc styling

This PR adds the zinc-button component to the React registry.

Files added/updated:
- apps/v4/registry/new-york-v4/ui/zinc-button.tsx
- apps/v4/registry/new-york-v4/examples/zinc-button-demo.tsx