### PR TITLE
Add green-button component

### DIFF
--- a/apps/v4/registry/new-york-v4/examples/green-button-demo.tsx
+++ b/apps/v4/registry/new-york-v4/examples/green-button-demo.tsx
@@ -1,0 +1,14 @@
+import { GreenButton } from "@/registry/new-york-v4/ui/green-button"
+
+export default function GreenButtonDemo() {
+  return (
+    <div className="flex items-center space-x-4">
+      <GreenButton>Default</GreenButton>
+      <GreenButton variant="secondary">Secondary</GreenButton>
+      <GreenButton variant="outline">Outline</GreenButton>
+      <GreenButton variant="ghost">Ghost</GreenButton>
+      <GreenButton size="sm">Small</GreenButton>
+      <GreenButton size="lg">Large</GreenButton>
+    </div>
+  )
+}

--- a/apps/v4/registry/new-york-v4/ui/green-button.tsx
+++ b/apps/v4/registry/new-york-v4/ui/green-button.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+import { cn } from "@/lib/utils"
+
+const green-buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+        green: "bg-green-500 text-white hover:bg-green-600",
+        dark-green: "bg-green-700 text-white hover:bg-green-800",
+        green-outline: "border-2 border-green-500 text-green-500 bg-transparent hover:bg-green-500/10",
+        green-ghost: "bg-transparent text-green-500 hover:bg-green-500/10"
+      },
+      size: {
+        default: "h-10 rounded-md px-4 py-2",
+        sm: "h-9 rounded-md px-3 text-sm",
+        lg: "h-11 rounded-md px-8 text-lg",
+        icon: "h-10 w-10",
+        sm: "h-9 rounded-md px-3 text-sm",
+        default: "h-10 rounded-md px-4 py-2",
+        lg: "h-11 rounded-md px-8 text-lg"
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface GreenButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof green-buttonVariants> {
+  asChild?: boolean
+}
+
+const GreenButton = React.forwardRef<HTMLButtonElement, GreenButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(green-buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+GreenButton.displayName = "GreenButton"
+
+export { GreenButton, green-buttonVariants }


### PR DESCRIPTION
Add green-button component with green styling variants

This PR adds the green-button component to the React registry.

Files added/updated:
- apps/v4/registry/new-york-v4/ui/green-button.tsx
- apps/v4/registry/new-york-v4/examples/green-button-demo.tsx