### PR TITLE
Add red-black-button component

### DIFF
--- a/apps/v4/registry/new-york-v4/examples/red-black-button-demo.tsx
+++ b/apps/v4/registry/new-york-v4/examples/red-black-button-demo.tsx
@@ -1,0 +1,28 @@
+import { RedBlackButton } from "./red-black-button-corrected"
+
+export default function RedBlackButtonDemo() {
+  return (
+    <div className="flex flex-col items-center space-y-4 p-8">
+      <h2 className="text-2xl font-bold">Red & Black Button Variants</h2>
+      
+      <div className="flex flex-wrap items-center justify-center gap-4">
+        <RedBlackButton>Red Button</RedBlackButton>
+        <RedBlackButton variant="black">Black Button</RedBlackButton>
+        <RedBlackButton variant="red-outline">Red Outline</RedBlackButton>
+        <RedBlackButton variant="red-ghost">Red Ghost</RedBlackButton>
+      </div>
+      
+      <div className="flex flex-wrap items-center justify-center gap-4">
+        <RedBlackButton size="sm" variant="red">Small Red</RedBlackButton>
+        <RedBlackButton size="sm" variant="black">Small Black</RedBlackButton>
+        <RedBlackButton size="sm" variant="red-outline">Small Outline</RedBlackButton>
+      </div>
+      
+      <div className="flex flex-wrap items-center justify-center gap-4">
+        <RedBlackButton size="lg" variant="red">Large Red</RedBlackButton>
+        <RedBlackButton size="lg" variant="black">Large Black</RedBlackButton>
+        <RedBlackButton size="lg" variant="red-outline">Large Outline</RedBlackButton>
+      </div>
+    </div>
+  )
+}

--- a/apps/v4/registry/new-york-v4/ui/red-black-button.tsx
+++ b/apps/v4/registry/new-york-v4/ui/red-black-button.tsx
@@ -1,0 +1,56 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+import { cn } from "@/lib/utils"
+
+const redBlackButtonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+        red: "bg-red-600 text-white hover:bg-red-700",
+        black: "bg-black text-white hover:bg-gray-800",
+        "red-outline": "border-2 border-red-600 text-red-600 bg-transparent hover:bg-red-600/10",
+        "red-ghost": "bg-transparent text-red-600 hover:bg-red-600/10"
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10"
+      },
+    },
+    defaultVariants: {
+      variant: "red",
+      size: "default",
+    },
+  }
+)
+
+export interface RedBlackButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof redBlackButtonVariants> {
+  asChild?: boolean
+}
+
+const RedBlackButton = React.forwardRef<HTMLButtonElement, RedBlackButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(redBlackButtonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+RedBlackButton.displayName = "RedBlackButton"
+
+export { RedBlackButton, redBlackButtonVariants }


### PR DESCRIPTION
Add red-black-button component with red and black styling

This PR adds the red-black-button component to the React registry.

Files added/updated:
- apps/v4/registry/new-york-v4/ui/red-black-button.tsx
- apps/v4/registry/new-york-v4/examples/red-black-button-demo.tsx